### PR TITLE
Added configurable option for save_to_sent_items

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ You can install the package via composer:
 ```bash
 composer require innoge/laravel-msgraph-mail
 ```
+
 ### Compatibility
+
 Laravel 10.x and 9.x are supported.
 
 ## Configuration
@@ -23,6 +25,7 @@ Laravel 10.x and 9.x are supported.
 ### Register the Azure App
 
 ### Microsoft Azure AD Configuration
+
 I have written a detailed Blog Post how you can configure your Microsoft Azure AD Tenant. [Sending Mails with Laravel and Microsoft Office 365 the secure way](https://geisi.dev/blog/getting-rid-of-deprecated-microsoft-office-365-smtp-mail-sending)
 
 ### I want to figure it out on my own
@@ -50,11 +53,16 @@ First you need to add a new entry to the mail drivers array in your `config/mail
         'address' => env('MAIL_FROM_ADDRESS'),
         'name' => env('MAIL_FROM_NAME'),
     ],
+    'save_to_sent_items' =>  env('MAIL_SAVE_TO_SENT_ITEMS'),
 ],
 ```
 
 For the `client_id`, `client_secret` and `tenant_id` you need to use the values from the Azure App you created in the
 previous step.
+
+The `save_to_sent_items` option in Microsoft Graph refers to a parameter that determines whether a sent email should be saved to the sender's "Sent Items" folder within their mailbox. When this option is set to true, the email will be automatically saved to the "Sent Items" folder, providing a record of the communication. Conversely, when it's set to false, the email will not be saved to the "Sent Items" folder.
+
+By default, the save_to_sent_items option is set to false, which means that emails sent through Microsoft Graph won't be saved in the sender's "Sent Items" folder unless explicitly specified otherwise. This behavior can be useful in scenarios where you might want more control over which emails are saved as sent items, perhaps to reduce clutter or ensure confidentiality.
 
 Now you can switch your default mail driver to the new `microsoft-graph` driver by setting the env variable:
 
@@ -82,8 +90,8 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 ## Credits
 
-- [Tim Geisendoerfer](https://github.com/InnoGE)
-- [All Contributors](../../contributors)
+-   [Tim Geisendoerfer](https://github.com/InnoGE)
+-   [All Contributors](../../contributors)
 
 ## License
 

--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -48,7 +48,7 @@ class MicrosoftGraphTransport extends AbstractTransport
                 'sender' => $this->transformEmailAddress($envelope->getSender()),
                 'attachments' => $this->getAttachments($email),
             ],
-            'saveToSentItems' => false,
+            'saveToSentItems' =>  config('mail.mailers.microsoft-graph.save_to_sent_items', false),
         ];
 
         $this->microsoftGraphApiService->sendMail($this->from, $payload);
@@ -86,7 +86,7 @@ class MicrosoftGraphTransport extends AbstractTransport
     protected function getRecipients(Email $email, Envelope $envelope): Collection
     {
         return collect($envelope->getRecipients())
-            ->filter(fn (Address $address) => ! in_array($address, array_merge($email->getCc(), $email->getBcc()), true));
+            ->filter(fn (Address $address) => !in_array($address, array_merge($email->getCc(), $email->getBcc()), true));
     }
 
     protected function getAttachments(Email $email): array


### PR DESCRIPTION
The `save_to_sent_items` option in Microsoft Graph refers to a parameter that determines whether a sent email should be saved to the sender's "Sent Items" folder within their mailbox. When this option is set to true, the email will be automatically saved to the "Sent Items" folder, providing a record of the communication. Conversely, when it's set to false, the email will not be saved to the "Sent Items" folder.

By default, the save_to_sent_items option is set to false, which means that emails sent through Microsoft Graph won't be saved in the sender's "Sent Items" folder unless explicitly specified otherwise. This behavior can be useful in scenarios where you might want more control over which emails are saved as sent items, perhaps to reduce clutter or ensure confidentiality.