### PR TITLE
Fix MicrosoftGraphTransport to handle sending from alias (#26)

### DIFF
--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -93,7 +93,6 @@ class MicrosoftGraphTransport extends AbstractTransport
      */
     protected function transformEmailAddresses(Collection $recipients): array
     {
-        info(json_encode($recipients));
         return $recipients
             ->map(fn (Address $recipient) => $this->transformEmailAddress($recipient))
             ->toArray();


### PR DESCRIPTION
To send the email from an alias

After assigning Send As to the user set the following config.

add a new config to use alias as from address

 ```php
'send_from_alias'=> true
```

full configuration will be as follows 

```php
'microsoft-graph' => [
      'transport' => 'microsoft-graph',
      'client_id' => env('MICROSOFT_GRAPH_CLIENT_ID'),
      'client_secret' => env('MICROSOFT_GRAPH_CLIENT_SECRET'),
      'tenant_id' => env('MICROSOFT_GRAPH_TENANT_ID'),
      'from' => [
          'address' => env('MAIL_FROM_ADDRESS'),
          'name' => env('MAIL_FROM_NAME'),
      ],
      'send_from_alias'=> true,
]
```

also create a new environment variable to set send from alias address

`
MAIL_FROM_ALIAS="info@example.com"
`