### PR TITLE
Support custom mail headers

### DIFF
--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -61,7 +61,7 @@ class MicrosoftGraphTransport extends AbstractTransport
             'saveToSentItems' => config('mail.mailers.microsoft-graph.save_to_sent_items', false) ?? false,
         ];
         if ($headers !== null) {
-            $payload['internetMessageHeaders'] = $headers;
+            $payload['message']['internetMessageHeaders'] = $headers;
         }
 
         $this->microsoftGraphApiService->sendMail($envelope->getSender()->getAddress(), $payload);

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -520,3 +520,95 @@ test('the configured mail sender can be overwritten', function () {
         return true;
     });
 });
+
+
+it('sends custom mail headers with microsoft graph', function () {
+    Config::set('mail.mailers.microsoft-graph', [
+        'transport' => 'microsoft-graph',
+        'client_id' => 'foo_client_id',
+        'client_secret' => 'foo_client_secret',
+        'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
+        'save_to_sent_items' => null,
+    ]);
+    Config::set('mail.default', 'microsoft-graph');
+
+    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+
+    Http::fake();
+
+    Mail::to('caleb@livewire.com')
+        ->bcc('tim@innoge.de')
+        ->cc('nuno@laravel.com')
+        ->send(new TestMail(includeHeaders: true));
+
+    Http::assertSent(function (Request $value) {
+        expect($value)
+            ->url()->toBe('https://graph.microsoft.com/v1.0/users/taylor@laravel.com/sendMail')
+            ->hasHeader('Authorization', 'Bearer foo_access_token')->toBeTrue()
+            ->body()->json()->toBe([
+                'message' => [
+                    'subject' => 'Dev Test',
+                    'body' => [
+                        'contentType' => 'HTML',
+                        'content' => '<b>Test</b>'.PHP_EOL,
+                    ],
+                    'toRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'caleb@livewire.com',
+                            ],
+                        ],
+                    ],
+                    'ccRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'nuno@laravel.com',
+                            ],
+                        ],
+                    ],
+                    'bccRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'tim@innoge.de',
+                            ],
+                        ],
+                    ],
+                    'replyTo' => [],
+                    'sender' => [
+                        'emailAddress' => [
+                            'address' => 'taylor@laravel.com',
+                        ],
+                    ],
+                    'attachments' => [
+                        [
+                            '@odata.type' => '#microsoft.graph.fileAttachment',
+                            'name' => 'test-file-1.txt',
+                            'contentType' => 'text',
+                            'contentBytes' => 'Zm9vCg==',
+                            'contentId' => 'test-file-1.txt',
+                            'isInline' => false,
+                        ],
+                        [
+                            '@odata.type' => '#microsoft.graph.fileAttachment',
+                            'name' => 'test-file-2.txt',
+                            'contentType' => 'text',
+                            'contentBytes' => 'Zm9vCg==',
+                            'contentId' => 'test-file-2.txt',
+                            'isInline' => false,
+                        ],
+                    ],
+                ],
+                'saveToSentItems' => false,
+                'internetMessageHeaders' => [[
+                    'name' => 'X-Custom-Header',
+                    'value' => 'Custom Header'
+                ]]
+            ]);
+
+        return true;
+    });
+});

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -601,12 +601,12 @@ it('sends custom mail headers with microsoft graph', function () {
                             'isInline' => false,
                         ],
                     ],
+                    'internetMessageHeaders' => [[
+                        'name' => 'X-Custom-Header',
+                        'value' => 'Custom Header'
+                    ]]
                 ],
-                'saveToSentItems' => false,
-                'internetMessageHeaders' => [[
-                    'name' => 'X-Custom-Header',
-                    'value' => 'Custom Header'
-                ]]
+                'saveToSentItems' => false
             ]);
 
         return true;

--- a/tests/Stubs/TestMail.php
+++ b/tests/Stubs/TestMail.php
@@ -7,6 +7,7 @@ use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Mail\Mailables\Headers;
 use Illuminate\Queue\SerializesModels;
 
 class TestMail extends Mailable
@@ -18,7 +19,9 @@ class TestMail extends Mailable
      *
      * @return void
      */
-    public function __construct(private readonly bool $isHtml = true) {}
+    public function __construct(private readonly bool $isHtml = true, private readonly bool $includeHeaders = false)
+    {
+    }
 
     /**
      * Get the message envelope.
@@ -39,7 +42,7 @@ class TestMail extends Mailable
      */
     public function content()
     {
-        if (! $this->isHtml) {
+        if (!$this->isHtml) {
             return new Content(text: 'text-mail');
         }
 
@@ -55,5 +58,16 @@ class TestMail extends Mailable
             Attachment::fromPath('tests/Resources/files/test-file-1.txt'),
             Attachment::fromPath('tests/Resources/files/test-file-2.txt'),
         ];
+    }
+
+
+    public function headers(): Headers
+    {
+        if ($this->includeHeaders) {
+            return new Headers(text: [
+                'X-Custom-Header' => 'Custom Header',
+            ]);
+        }
+        return new Headers();
     }
 }


### PR DESCRIPTION
Thanks for your work on this project.

Using the [Docs](https://learn.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0&tabs=http#example-2-create-a-message-with-custom-internet-message-headers-and-send-the-message) I've added the option to be able to provide custom mail headers

Please let me know if you need any changes.

Thanks