### PR TITLE
Allow fallback to global from instead of forcing repetition

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ First you need to add a new entry to the mail drivers array in your `config/mail
     'client_id' => env('MICROSOFT_GRAPH_CLIENT_ID'),
     'client_secret' => env('MICROSOFT_GRAPH_CLIENT_SECRET'),
     'tenant_id' => env('MICROSOFT_GRAPH_TENANT_ID'),
-    'from' => [
-        'address' => env('MAIL_FROM_ADDRESS'),
-        'name' => env('MAIL_FROM_NAME'),
-    ],
     'save_to_sent_items' =>  env('MAIL_SAVE_TO_SENT_ITEMS', false),
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -49,12 +49,24 @@ First you need to add a new entry to the mail drivers array in your `config/mail
 ],
 ```
 
-For the `client_id`, `client_secret` and `tenant_id` you need to use the values from the Azure App you created in the
-previous step.
+For the `client_id`, `client_secret` and `tenant_id` you need to use the values from the Azure App you created in the previous step.
 
-The `save_to_sent_items` option in Microsoft Graph refers to a parameter that determines whether a sent email should be saved to the sender's "Sent Items" folder within their mailbox. When this option is set to true, the email will be automatically saved to the "Sent Items" folder, providing a record of the communication. Conversely, when it's set to false, the email will not be saved to the "Sent Items" folder.
+The `save_to_sent_items` option in Microsoft Graph refers to a parameter that determines whether a sent email should be saved to the sender's "Sent Items" folder within their mailbox.
+When this option is set to true, the email will be automatically saved to the "Sent Items" folder, providing a record of the communication.
+Conversely, when it's set to false, the email will not be saved to the "Sent Items" folder.
+By default, the `save_to_sent_items` option is set to false, which means that emails sent through Microsoft Graph won't be saved in the sender's "Sent Items" folder unless explicitly specified otherwise. This behavior can be useful in scenarios where you might want more control over which emails are saved as sent items, perhaps to reduce clutter or ensure confidentiality.
 
-By default, the save_to_sent_items option is set to false, which means that emails sent through Microsoft Graph won't be saved in the sender's "Sent Items" folder unless explicitly specified otherwise. This behavior can be useful in scenarios where you might want more control over which emails are saved as sent items, perhaps to reduce clutter or ensure confidentiality.
+If you need to override the default sender in `mail.from`, you can add the following to the configuration entry:
+
+```php
+'microsoft-graph' => [
+    ...,
+    'from' => [
+        'address' => env('MAIL_FROM_ADDRESS'),
+        'name' => env('MAIL_FROM_NAME'),
+    ],
+]
+```
 
 Now you can switch your default mail driver to the new `microsoft-graph` driver by setting the env variable:
 

--- a/src/LaravelMsGraphMailServiceProvider.php
+++ b/src/LaravelMsGraphMailServiceProvider.php
@@ -25,8 +25,6 @@ class LaravelMsGraphMailServiceProvider extends PackageServiceProvider
     public function boot(): void
     {
         Mail::extend('microsoft-graph', function (array $config): MicrosoftGraphTransport {
-            throw_if(blank($config['from']['address'] ?? []), new ConfigurationMissing('from.address'));
-
             $accessTokenTtl = $config['access_token_ttl'] ?? 3000;
             if (! is_int($accessTokenTtl)) {
                 throw new ConfigurationInvalid('access_token_ttl', $accessTokenTtl);

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -18,13 +18,13 @@ it('sends html mails with microsoft graph', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
-        'from' => [
-            'address' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ],
         'save_to_sent_items' => null,
     ]);
     Config::set('mail.default', 'microsoft-graph');
+    Config::set('mail.from', [
+        'address' => 'taylor@laravel.com',
+        'name' => 'Taylor Otwell',
+    ]);
 
     Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
 
@@ -105,12 +105,12 @@ it('sends text mails with microsoft graph', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
-        'from' => [
-            'address' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ],
     ]);
     Config::set('mail.default', 'microsoft-graph');
+    Config::set('mail.from', [
+        'address' => 'taylor@laravel.com',
+        'name' => 'Taylor Otwell',
+    ]);
 
     Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
 
@@ -191,10 +191,6 @@ it('creates an oauth access token', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
-        'from' => [
-            'address' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ],
     ]);
     Config::set('mail.default', 'microsoft-graph');
 
@@ -227,10 +223,6 @@ it('throws exceptions on invalid access token in response', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
-        'from' => [
-            'address' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ],
     ]);
     Config::set('mail.default', 'microsoft-graph');
 
@@ -247,17 +239,13 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
     Config::set('mail.default', 'microsoft-graph');
 
     expect(fn () => Mail::to('caleb@livewire.com')->send(new TestMail(false)))
-        ->toThrow(get_class($exception), $exception->getMessage());
+        ->toThrow($exception);
 })->with([
     [
         [
             'transport' => 'microsoft-graph',
             'client_id' => 'foo_client_id',
             'client_secret' => 'foo_client_secret',
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationMissing('tenant_id'),
     ],
@@ -267,10 +255,6 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
             'tenant_id' => 123,
             'client_id' => 'foo_client_id',
             'client_secret' => 'foo_client_secret',
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationInvalid('tenant_id', 123),
     ],
@@ -279,10 +263,6 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
             'transport' => 'microsoft-graph',
             'tenant_id' => 'foo_tenant_id',
             'client_secret' => 'foo_client_secret',
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationMissing('client_id'),
     ],
@@ -292,10 +272,6 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
             'tenant_id' => 'foo_tenant_id',
             'client_id' => '',
             'client_secret' => 'foo_client_secret',
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationInvalid('client_id', ''),
     ],
@@ -304,10 +280,6 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
             'transport' => 'microsoft-graph',
             'tenant_id' => 'foo_tenant_id',
             'client_id' => 'foo_client_id',
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationMissing('client_secret'),
     ],
@@ -317,10 +289,6 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
             'tenant_id' => 'foo_tenant_id',
             'client_id' => 'foo_client_id',
             'client_secret' => null,
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationInvalid('client_secret', null),
     ],
@@ -330,20 +298,7 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
             'tenant_id' => 'foo_tenant_id',
             'client_id' => 'foo_client_id',
             'client_secret' => 'foo_client_secret',
-        ],
-        new ConfigurationMissing('from.address'),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 'foo_tenant_id',
-            'client_id' => 'foo_client_id',
-            'client_secret' => 'foo_client_secret',
             'access_token_ttl' => false,
-            'from' => [
-                'address' => 'taylor@laravel.com',
-                'name' => 'Taylor Otwell',
-            ],
         ],
         new ConfigurationInvalid('access_token_ttl', false),
     ],
@@ -355,10 +310,10 @@ it('sends html mails with inline images with microsoft graph', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
-        'from' => [
-            'address' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ],
+    ]);
+    Config::set('mail.from', [
+        'address' => 'taylor@laravel.com',
+        'name' => 'Taylor Otwell',
     ]);
     Config::set('mail.default', 'microsoft-graph');
     Config::set('filesystems.default', 'local');
@@ -438,10 +393,6 @@ test('the configured mail sender can be overwritten', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
-        'from' => [
-            'address' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ],
     ]);
     Config::set('mail.default', 'microsoft-graph');
 

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -18,13 +18,13 @@ it('sends html mails with microsoft graph', function () {
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
         'save_to_sent_items' => null,
     ]);
     Config::set('mail.default', 'microsoft-graph');
-    Config::set('mail.from', [
-        'address' => 'taylor@laravel.com',
-        'name' => 'Taylor Otwell',
-    ]);
 
     Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
 
@@ -100,6 +100,330 @@ it('sends html mails with microsoft graph', function () {
 });
 
 it('sends text mails with microsoft graph', function () {
+    Config::set('mail.mailers.microsoft-graph', [
+        'transport' => 'microsoft-graph',
+        'client_id' => 'foo_client_id',
+        'client_secret' => 'foo_client_secret',
+        'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
+    ]);
+    Config::set('mail.default', 'microsoft-graph');
+
+    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+
+    Http::fake();
+
+    Mail::to('caleb@livewire.com')
+        ->bcc('tim@innoge.de')
+        ->cc('nuno@laravel.com')
+        ->send(new TestMail(false));
+
+    Http::assertSent(function (Request $value) {
+        expect($value)
+            ->url()->toBe('https://graph.microsoft.com/v1.0/users/taylor@laravel.com/sendMail')
+            ->hasHeader('Authorization', 'Bearer foo_access_token')->toBeTrue()
+            ->body()->json()->toBe([
+                'message' => [
+                    'subject' => 'Dev Test',
+                    'body' => [
+                        'contentType' => 'Text',
+                        'content' => 'Test'.PHP_EOL,
+                    ],
+                    'toRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'caleb@livewire.com',
+                            ],
+                        ],
+                    ],
+                    'ccRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'nuno@laravel.com',
+                            ],
+                        ],
+                    ],
+                    'bccRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'tim@innoge.de',
+                            ],
+                        ],
+                    ],
+                    'replyTo' => [],
+                    'sender' => [
+                        'emailAddress' => [
+                            'address' => 'taylor@laravel.com',
+                        ],
+                    ],
+                    'attachments' => [
+                        [
+                            '@odata.type' => '#microsoft.graph.fileAttachment',
+                            'name' => 'test-file-1.txt',
+                            'contentType' => 'text',
+                            'contentBytes' => 'Zm9vCg==',
+                            'contentId' => 'test-file-1.txt',
+                            'isInline' => false,
+                        ],
+                        [
+                            '@odata.type' => '#microsoft.graph.fileAttachment',
+                            'name' => 'test-file-2.txt',
+                            'contentType' => 'text',
+                            'contentBytes' => 'Zm9vCg==',
+                            'contentId' => 'test-file-2.txt',
+                            'isInline' => false,
+                        ],
+                    ],
+                ],
+                'saveToSentItems' => false,
+            ]);
+
+        return true;
+    });
+});
+
+it('creates an oauth access token', function () {
+    Config::set('mail.mailers.microsoft-graph', [
+        'transport' => 'microsoft-graph',
+        'client_id' => 'foo_client_id',
+        'client_secret' => 'foo_client_secret',
+        'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
+    ]);
+    Config::set('mail.default', 'microsoft-graph');
+
+    Http::fake([
+        'https://login.microsoftonline.com/foo_tenant_id/oauth2/v2.0/token' => Http::response(['access_token' => 'foo_access_token']),
+        'https://graph.microsoft.com/v1.0*' => Http::response(['value' => []]),
+    ]);
+
+    Mail::to('caleb@livewire.com')
+        ->send(new TestMail(false));
+
+    Http::assertSent(function (Request $request) {
+        if (Str::startsWith($request->url(), 'https://login.microsoftonline.com')) {
+            expect($request)
+                ->url()->toBe('https://login.microsoftonline.com/foo_tenant_id/oauth2/v2.0/token')
+                ->isForm()->toBeTrue()
+                ->body()->toBe('grant_type=client_credentials&client_id=foo_client_id&client_secret=foo_client_secret&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default');
+        }
+
+        return true;
+    });
+
+    expect(Cache::get('microsoft-graph-api-access-token'))
+        ->toBe('foo_access_token');
+});
+
+it('throws exceptions on invalid access token in response', function () {
+    Config::set('mail.mailers.microsoft-graph', [
+        'transport' => 'microsoft-graph',
+        'client_id' => 'foo_client_id',
+        'client_secret' => 'foo_client_secret',
+        'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
+    ]);
+    Config::set('mail.default', 'microsoft-graph');
+
+    Http::fake([
+        'https://login.microsoftonline.com/foo_tenant_id/oauth2/v2.0/token' => Http::response(['access_token' => 123]),
+    ]);
+
+    expect(fn () => Mail::to('caleb@livewire.com')->send(new TestMail(false)))
+        ->toThrow(InvalidResponse::class, 'Expected response to contain key access_token of type string, got: 123.');
+});
+
+it('throws exceptions when config is invalid', function (array $config, Exception $exception) {
+    Config::set('mail.mailers.microsoft-graph', $config);
+    Config::set('mail.default', 'microsoft-graph');
+
+    expect(fn () => Mail::to('caleb@livewire.com')->send(new TestMail(false)))
+        ->toThrow(get_class($exception), $exception->getMessage());
+})->with([
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'client_id' => 'foo_client_id',
+            'client_secret' => 'foo_client_secret',
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationMissing('tenant_id'),
+    ],
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'tenant_id' => 123,
+            'client_id' => 'foo_client_id',
+            'client_secret' => 'foo_client_secret',
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationInvalid('tenant_id', 123),
+    ],
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'tenant_id' => 'foo_tenant_id',
+            'client_secret' => 'foo_client_secret',
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationMissing('client_id'),
+    ],
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'tenant_id' => 'foo_tenant_id',
+            'client_id' => '',
+            'client_secret' => 'foo_client_secret',
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationInvalid('client_id', ''),
+    ],
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'tenant_id' => 'foo_tenant_id',
+            'client_id' => 'foo_client_id',
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationMissing('client_secret'),
+    ],
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'tenant_id' => 'foo_tenant_id',
+            'client_id' => 'foo_client_id',
+            'client_secret' => null,
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationInvalid('client_secret', null),
+    ],
+    [
+        [
+            'transport' => 'microsoft-graph',
+            'tenant_id' => 'foo_tenant_id',
+            'client_id' => 'foo_client_id',
+            'client_secret' => 'foo_client_secret',
+            'access_token_ttl' => false,
+            'from' => [
+                'address' => 'taylor@laravel.com',
+                'name' => 'Taylor Otwell',
+            ],
+        ],
+        new ConfigurationInvalid('access_token_ttl', false),
+    ],
+]);
+
+it('sends html mails with inline images with microsoft graph', function () {
+    Config::set('mail.mailers.microsoft-graph', [
+        'transport' => 'microsoft-graph',
+        'client_id' => 'foo_client_id',
+        'client_secret' => 'foo_client_secret',
+        'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
+    ]);
+    Config::set('mail.default', 'microsoft-graph');
+    Config::set('filesystems.default', 'local');
+    Config::set('filesystems.disks.local.root', realpath(__DIR__.'/Resources/files'));
+
+    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+
+    Http::fake();
+
+    Mail::to('caleb@livewire.com')
+        ->bcc('tim@innoge.de')
+        ->cc('nuno@laravel.com')
+        ->send(new TestMailWithInlineImage);
+
+    Http::assertSent(function (Request $value) {
+        // ContentId gets random generated, so get this value first and check for equality later
+        $inlineImageContentId = json_decode($value->body())->message->attachments[0]->contentId;
+
+        expect($value)
+            ->url()->toBe('https://graph.microsoft.com/v1.0/users/taylor@laravel.com/sendMail')
+            ->hasHeader('Authorization', 'Bearer foo_access_token')->toBeTrue()
+            ->body()->json()->toBe([
+                'message' => [
+                    'subject' => 'Dev Test',
+                    'body' => [
+                        'contentType' => 'HTML',
+                        'content' => '<b>Test</b><img src="cid:'.$inlineImageContentId.'">'.PHP_EOL,
+                    ],
+                    'toRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'caleb@livewire.com',
+                            ],
+                        ],
+                    ],
+                    'ccRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'nuno@laravel.com',
+                            ],
+                        ],
+                    ],
+                    'bccRecipients' => [
+                        [
+                            'emailAddress' => [
+                                'address' => 'tim@innoge.de',
+                            ],
+                        ],
+                    ],
+                    'replyTo' => [],
+                    'sender' => [
+                        'emailAddress' => [
+                            'address' => 'taylor@laravel.com',
+                        ],
+                    ],
+                    'attachments' => [
+                        [
+                            '@odata.type' => '#microsoft.graph.fileAttachment',
+                            'name' => $inlineImageContentId,
+                            'contentType' => 'image',
+                            'contentBytes' => '/9j/4AAQSkZJRgABAQEASABIAAD//gATQ3JlYXRlZCB3aXRoIEdJTVD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wgARCABLAGQDAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAWAQEBAQAAAAAAAAAAAAAAAAAABQj/2gAMAwEAAhADEAAAAZ71TDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAEFAgL/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAEDAQE/AQL/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAECAQE/AQL/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAY/AgL/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAE/IQL/2gAMAwEAAgADAAAAEEkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkv/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAEDAQE/EAL/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAECAQE/EAL/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAE/EAL/2Q==',
+                            'contentId' => $inlineImageContentId,
+                            'isInline' => true,
+                        ],
+                    ],
+                ],
+                'saveToSentItems' => false,
+            ]);
+
+        return true;
+    });
+});
+
+test('default from', function () {
     Config::set('mail.mailers.microsoft-graph', [
         'transport' => 'microsoft-graph',
         'client_id' => 'foo_client_id',
@@ -185,214 +509,16 @@ it('sends text mails with microsoft graph', function () {
     });
 });
 
-it('creates an oauth access token', function () {
-    Config::set('mail.mailers.microsoft-graph', [
-        'transport' => 'microsoft-graph',
-        'client_id' => 'foo_client_id',
-        'client_secret' => 'foo_client_secret',
-        'tenant_id' => 'foo_tenant_id',
-    ]);
-    Config::set('mail.default', 'microsoft-graph');
-
-    Http::fake([
-        'https://login.microsoftonline.com/foo_tenant_id/oauth2/v2.0/token' => Http::response(['access_token' => 'foo_access_token']),
-        'https://graph.microsoft.com/v1.0*' => Http::response(['value' => []]),
-    ]);
-
-    Mail::to('caleb@livewire.com')
-        ->send(new TestMail(false));
-
-    Http::assertSent(function (Request $request) {
-        if (Str::startsWith($request->url(), 'https://login.microsoftonline.com')) {
-            expect($request)
-                ->url()->toBe('https://login.microsoftonline.com/foo_tenant_id/oauth2/v2.0/token')
-                ->isForm()->toBeTrue()
-                ->body()->toBe('grant_type=client_credentials&client_id=foo_client_id&client_secret=foo_client_secret&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default');
-        }
-
-        return true;
-    });
-
-    expect(Cache::get('microsoft-graph-api-access-token'))
-        ->toBe('foo_access_token');
-});
-
-it('throws exceptions on invalid access token in response', function () {
-    Config::set('mail.mailers.microsoft-graph', [
-        'transport' => 'microsoft-graph',
-        'client_id' => 'foo_client_id',
-        'client_secret' => 'foo_client_secret',
-        'tenant_id' => 'foo_tenant_id',
-    ]);
-    Config::set('mail.default', 'microsoft-graph');
-
-    Http::fake([
-        'https://login.microsoftonline.com/foo_tenant_id/oauth2/v2.0/token' => Http::response(['access_token' => 123]),
-    ]);
-
-    expect(fn () => Mail::to('caleb@livewire.com')->send(new TestMail(false)))
-        ->toThrow(InvalidResponse::class, 'Expected response to contain key access_token of type string, got: 123.');
-});
-
-it('throws exceptions when config is invalid', function (array $config, Exception $exception) {
-    Config::set('mail.mailers.microsoft-graph', $config);
-    Config::set('mail.default', 'microsoft-graph');
-
-    expect(fn () => Mail::to('caleb@livewire.com')->send(new TestMail(false)))
-        ->toThrow(get_class($exception), $exception->getMessage());
-})->with([
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'client_id' => 'foo_client_id',
-            'client_secret' => 'foo_client_secret',
-        ],
-        new ConfigurationMissing('tenant_id'),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 123,
-            'client_id' => 'foo_client_id',
-            'client_secret' => 'foo_client_secret',
-        ],
-        new ConfigurationInvalid('tenant_id', 123),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 'foo_tenant_id',
-            'client_secret' => 'foo_client_secret',
-        ],
-        new ConfigurationMissing('client_id'),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 'foo_tenant_id',
-            'client_id' => '',
-            'client_secret' => 'foo_client_secret',
-        ],
-        new ConfigurationInvalid('client_id', ''),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 'foo_tenant_id',
-            'client_id' => 'foo_client_id',
-        ],
-        new ConfigurationMissing('client_secret'),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 'foo_tenant_id',
-            'client_id' => 'foo_client_id',
-            'client_secret' => null,
-        ],
-        new ConfigurationInvalid('client_secret', null),
-    ],
-    [
-        [
-            'transport' => 'microsoft-graph',
-            'tenant_id' => 'foo_tenant_id',
-            'client_id' => 'foo_client_id',
-            'client_secret' => 'foo_client_secret',
-            'access_token_ttl' => false,
-        ],
-        new ConfigurationInvalid('access_token_ttl', false),
-    ],
-]);
-
-it('sends html mails with inline images with microsoft graph', function () {
-    Config::set('mail.mailers.microsoft-graph', [
-        'transport' => 'microsoft-graph',
-        'client_id' => 'foo_client_id',
-        'client_secret' => 'foo_client_secret',
-        'tenant_id' => 'foo_tenant_id',
-    ]);
-    Config::set('mail.from', [
-        'address' => 'taylor@laravel.com',
-        'name' => 'Taylor Otwell',
-    ]);
-    Config::set('mail.default', 'microsoft-graph');
-    Config::set('filesystems.default', 'local');
-    Config::set('filesystems.disks.local.root', realpath(__DIR__.'/Resources/files'));
-
-    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
-
-    Http::fake();
-
-    Mail::to('caleb@livewire.com')
-        ->bcc('tim@innoge.de')
-        ->cc('nuno@laravel.com')
-        ->send(new TestMailWithInlineImage);
-
-    Http::assertSent(function (Request $value) {
-        // ContentId gets random generated, so get this value first and check for equality later
-        $inlineImageContentId = json_decode($value->body())->message->attachments[0]->contentId;
-
-        expect($value)
-            ->url()->toBe('https://graph.microsoft.com/v1.0/users/taylor@laravel.com/sendMail')
-            ->hasHeader('Authorization', 'Bearer foo_access_token')->toBeTrue()
-            ->body()->json()->toBe([
-                'message' => [
-                    'subject' => 'Dev Test',
-                    'body' => [
-                        'contentType' => 'HTML',
-                        'content' => '<b>Test</b><img src="cid:'.$inlineImageContentId.'">'.PHP_EOL,
-                    ],
-                    'toRecipients' => [
-                        [
-                            'emailAddress' => [
-                                'address' => 'caleb@livewire.com',
-                            ],
-                        ],
-                    ],
-                    'ccRecipients' => [
-                        [
-                            'emailAddress' => [
-                                'address' => 'nuno@laravel.com',
-                            ],
-                        ],
-                    ],
-                    'bccRecipients' => [
-                        [
-                            'emailAddress' => [
-                                'address' => 'tim@innoge.de',
-                            ],
-                        ],
-                    ],
-                    'replyTo' => [],
-                    'sender' => [
-                        'emailAddress' => [
-                            'address' => 'taylor@laravel.com',
-                        ],
-                    ],
-                    'attachments' => [
-                        [
-                            '@odata.type' => '#microsoft.graph.fileAttachment',
-                            'name' => $inlineImageContentId,
-                            'contentType' => 'image',
-                            'contentBytes' => '/9j/4AAQSkZJRgABAQEASABIAAD//gATQ3JlYXRlZCB3aXRoIEdJTVD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wgARCABLAGQDAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAWAQEBAQAAAAAAAAAAAAAAAAAABQj/2gAMAwEAAhADEAAAAZ71TDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAEFAgL/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAEDAQE/AQL/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAECAQE/AQL/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAY/AgL/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAE/IQL/2gAMAwEAAgADAAAAEEkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkv/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAEDAQE/EAL/xAAUEQEAAAAAAAAAAAAAAAAAAABw/9oACAECAQE/EAL/xAAUEAEAAAAAAAAAAAAAAAAAAABw/9oACAEBAAE/EAL/2Q==',
-                            'contentId' => $inlineImageContentId,
-                            'isInline' => true,
-                        ],
-                    ],
-                ],
-                'saveToSentItems' => false,
-            ]);
-
-        return true;
-    });
-});
-
 test('the configured mail sender can be overwritten', function () {
     Config::set('mail.mailers.microsoft-graph', [
         'transport' => 'microsoft-graph',
         'client_id' => 'foo_client_id',
         'client_secret' => 'foo_client_secret',
         'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ],
     ]);
     Config::set('mail.default', 'microsoft-graph');
 

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -239,7 +239,7 @@ it('throws exceptions when config is invalid', function (array $config, Exceptio
     Config::set('mail.default', 'microsoft-graph');
 
     expect(fn () => Mail::to('caleb@livewire.com')->send(new TestMail(false)))
-        ->toThrow($exception);
+        ->toThrow(get_class($exception), $exception->getMessage());
 })->with([
     [
         [


### PR DESCRIPTION
Follow up to https://github.com/InnoGE/laravel-msgraph-mail/pull/35. As discussed, this change does not introduce any breaking changes. It merely removes a requirement to provide an explicit override or to repeat the default `mail.from` setting.