### PR TITLE
Add configurable send_as address with envelope fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,15 @@ First you need to add a new entry to the mail drivers array in your `config/mail
         'address' => env('MAIL_FROM_ADDRESS'),
         'name' => env('MAIL_FROM_NAME'),
     ],
+    'send_as' => env('MAIL_SEND_AS'),
     'save_to_sent_items' =>  env('MAIL_SAVE_TO_SENT_ITEMS', false),
 ],
 ```
 
 For the `client_id`, `client_secret` and `tenant_id` you need to use the values from the Azure App you created in the
 previous step.
+
+The `send_as` option is the email address which is the sender. When left blank then the default sender is used from the `from.address` parameter. To use a different sender the `from.address` (Azure User) must have access to this mailbox.
 
 The `save_to_sent_items` option in Microsoft Graph refers to a parameter that determines whether a sent email should be saved to the sender's "Sent Items" folder within their mailbox. When this option is set to true, the email will be automatically saved to the "Sent Items" folder, providing a record of the communication. Conversely, when it's set to false, the email will not be saved to the "Sent Items" folder.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ First you need to add a new entry to the mail drivers array in your `config/mail
 For the `client_id`, `client_secret` and `tenant_id` you need to use the values from the Azure App you created in the
 previous step.
 
-The `send_as` option is the email address which is the sender. When left blank then the default sender is used from the `from.address` parameter. To use a different sender the `from.address` (Azure User) must have access to this mailbox.
+The `send_as` option allows you to send mail from a shared or delegated mailbox. Set it to the email address of the shared mailbox. The `from.address` must be a licensed Azure AD user who has **Send As** permission on that shared mailbox. When `send_as` is left blank, mail is sent directly from the `from.address` account.
 
 The `save_to_sent_items` option in Microsoft Graph refers to a parameter that determines whether a sent email should be saved to the sender's "Sent Items" folder within their mailbox. When this option is set to true, the email will be automatically saved to the "Sent Items" folder, providing a record of the communication. Conversely, when it's set to false, the email will not be saved to the "Sent Items" folder.
 

--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -63,7 +63,10 @@ class MicrosoftGraphTransport extends AbstractTransport
             $payload['message']['internetMessageHeaders'] = $headers;
         }
 
-        $this->microsoftGraphApiService->sendMail($envelope->getSender()->getAddress(), $payload);
+        $this->microsoftGraphApiService->sendMail(!empty(config('mail.mailers.microsoft-graph.send_as'))
+            ? config('mail.mailers.microsoft-graph.send_as')
+            : $envelope->getSender()->getAddress(),
+            $payload);
     }
 
     /**

--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -42,6 +42,8 @@ class MicrosoftGraphTransport extends AbstractTransport
 
         [$attachments, $html] = $this->prepareAttachments($email, $html);
 
+        $sendAs = config('mail.mailers.microsoft-graph.send_as');
+
         $payload = [
             'message' => [
                 'subject' => $email->getSubject(),
@@ -54,6 +56,7 @@ class MicrosoftGraphTransport extends AbstractTransport
                 'bccRecipients' => $this->transformEmailAddresses(collect($email->getBcc())),
                 'replyTo' => $this->transformEmailAddresses(collect($email->getReplyTo())),
                 'sender' => $this->transformEmailAddress($envelope->getSender()),
+                ...(filled($sendAs) ? ['from' => ['emailAddress' => ['address' => $sendAs]]] : []),
                 'attachments' => $attachments,
             ],
             'saveToSentItems' => config('mail.mailers.microsoft-graph.save_to_sent_items', false) ?? false,
@@ -63,10 +66,7 @@ class MicrosoftGraphTransport extends AbstractTransport
             $payload['message']['internetMessageHeaders'] = $headers;
         }
 
-        $this->microsoftGraphApiService->sendMail(!empty(config('mail.mailers.microsoft-graph.send_as'))
-            ? config('mail.mailers.microsoft-graph.send_as')
-            : $envelope->getSender()->getAddress(),
-            $payload);
+        $this->microsoftGraphApiService->sendMail($envelope->getSender()->getAddress(), $payload);
     }
 
     /**

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -663,6 +663,37 @@ it('sends html mails with multiple inline images with unique content ids', funct
     });
 });
 
+it('sends mail from a delegated send_as address using the licensed user in the url', function () {
+    Config::set('mail.mailers.microsoft-graph', [
+        'transport' => 'microsoft-graph',
+        'client_id' => 'foo_client_id',
+        'client_secret' => 'foo_client_secret',
+        'tenant_id' => 'foo_tenant_id',
+        'from' => [
+            'address' => 'licensed@company.com',
+            'name' => 'Licensed User',
+        ],
+        'send_as' => 'shared-mailbox@company.com',
+    ]);
+    Config::set('mail.default', 'microsoft-graph');
+
+    Cache::set('microsoft-graph-api-access-token-foo_tenant_id', 'foo_access_token', 3600);
+
+    Http::fake();
+
+    Mail::to('caleb@livewire.com')->send(new TestMail(false));
+
+    Http::assertSent(function (Request $value) {
+        $body = json_decode($value->body(), true);
+
+        expect($value->url())->toBe('https://graph.microsoft.com/v1.0/users/licensed@company.com/sendMail');
+        expect($body['message']['sender']['emailAddress']['address'])->toBe('licensed@company.com');
+        expect($body['message']['from']['emailAddress']['address'])->toBe('shared-mailbox@company.com');
+
+        return true;
+    });
+});
+
 it('handles mixed inline and regular attachments correctly', function () {
     Config::set('mail.mailers.microsoft-graph', [
         'transport' => 'microsoft-graph',


### PR DESCRIPTION
## Summary

Adds support for sending mail from a shared or delegated mailbox via the `send_as` config option.

- `from.address` (`MAIL_FROM_ADDRESS`) is the **licensed Azure AD user** whose credentials are used to authenticate against the Microsoft Graph API (`/users/{licensed_user}/sendMail`).
- `send_as` (`MAIL_SEND_AS`) is the **shared or delegated mailbox** address that appears as the sender in the `from` field of the outgoing message.
- The licensed user must have **Send As** permission on the shared mailbox in Exchange Online.
- When `send_as` is not configured, mail is sent directly from the `from.address` account as before.

## Changes

- `MicrosoftGraphTransport`: always uses the licensed user in the Graph API URL; adds `message.from` to the payload when `send_as` is set.
- `MicrosoftGraphApiService`: no changes — `$from` was and remains the licensed user.
- `README`: updated to clarify the role of `from.address` vs `send_as`.
- Test added to verify correct URL and payload structure for the `send_as` scenario.