### PR TITLE
Add functionnality to have multiple mailers from the transport

### DIFF
--- a/src/Services/MicrosoftGraphApiService.php
+++ b/src/Services/MicrosoftGraphApiService.php
@@ -32,7 +32,7 @@ class MicrosoftGraphApiService
 
     protected function getAccessToken(): string
     {
-        return Cache::remember('microsoft-graph-api-access-token', $this->accessTokenTtl, function (): string {
+        return Cache::remember('microsoft-graph-api-access-token-'.$this->tenantId, $this->accessTokenTtl, function (): string {
             $response = Http::asForm()
                 ->post("https://login.microsoftonline.com/{$this->tenantId}/oauth2/v2.0/token",
                     [

--- a/tests/MicrosoftGraphTransportTest.php
+++ b/tests/MicrosoftGraphTransportTest.php
@@ -26,7 +26,7 @@ it('sends html mails with microsoft graph', function () {
     ]);
     Config::set('mail.default', 'microsoft-graph');
 
-    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+    Cache::set('microsoft-graph-api-access-token-foo_tenant_id', 'foo_access_token', 3600);
 
     Http::fake();
 
@@ -112,7 +112,7 @@ it('sends text mails with microsoft graph', function () {
     ]);
     Config::set('mail.default', 'microsoft-graph');
 
-    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+    Cache::set('microsoft-graph-api-access-token-foo_tenant_id', 'foo_access_token', 3600);
 
     Http::fake();
 
@@ -217,7 +217,7 @@ it('creates an oauth access token', function () {
         return true;
     });
 
-    expect(Cache::get('microsoft-graph-api-access-token'))
+    expect(Cache::get('microsoft-graph-api-access-token-foo_tenant_id'))
         ->toBe('foo_access_token');
 });
 
@@ -364,7 +364,7 @@ it('sends html mails with inline images with microsoft graph', function () {
     Config::set('filesystems.default', 'local');
     Config::set('filesystems.disks.local.root', realpath(__DIR__.'/Resources/files'));
 
-    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+    Cache::set('microsoft-graph-api-access-token-foo_tenant_id', 'foo_access_token', 3600);
 
     Http::fake();
 
@@ -445,7 +445,7 @@ test('the configured mail sender can be overwritten', function () {
     ]);
     Config::set('mail.default', 'microsoft-graph');
 
-    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+    Cache::set('microsoft-graph-api-access-token-foo_tenant_id', 'foo_access_token', 3600);
 
     Http::fake();
 
@@ -535,7 +535,7 @@ it('sends custom mail headers with microsoft graph', function () {
     ]);
     Config::set('mail.default', 'microsoft-graph');
 
-    Cache::set('microsoft-graph-api-access-token', 'foo_access_token', 3600);
+    Cache::set('microsoft-graph-api-access-token-foo_tenant_id', 'foo_access_token', 3600);
 
     Http::fake();
 


### PR DESCRIPTION
I needed to send send emails from 2 different tenants and the only thing that was blocking me was the token in the cache. So to keep the same functionnality and make sure we still cache the token so we don't generate a new one each time, I simply appended the tenantId to the cache key. 
So now we can cache more than 1 token and if we create multiple mailers with the 'microsoft-graph' transport, it works perfectly.

I also made the necessary corrections to the test so they all passed.