### PR TITLE
Fix laravel 12 inline mail attachements

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
         laravel: ["^12.0", "^11.0", "^10.0", "^9.38"]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -30,6 +30,12 @@ jobs:
             php: 8.1
           - laravel: "^12.0"
             php: 8.1
+          - laravel: "^11.0"
+            php: 8.5
+          - laravel: "^10.0"
+            php: 8.5
+          - laravel: "^9.38"
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2, 8.1]
         laravel: ["^12.0", "^11.0", "^10.0", "^9.38"]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -30,17 +30,7 @@ jobs:
             php: 8.1
           - laravel: "^12.0"
             php: 8.1
-          - laravel: "^12.0"
-            php: 8.5
-            stability: prefer-lowest
-          - laravel: "^11.0"
-            php: 8.5
-          - laravel: "^10.0"
-            php: 8.5
-          - laravel: "^9.38"
-            php: 8.5
-          - laravel: "^10.0"
-            stability: prefer-lowest
+
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,8 @@ jobs:
             php: 8.1
           - laravel: "^12.0"
             php: 8.1
+          - laravel: "^11.0"
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,8 @@ jobs:
             php: 8.1
           - laravel: "^11.0"
             stability: prefer-lowest
+          - laravel: "^10.0"
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Remove larastan from dev dependencies
-        run: composer remove --dev nunomaduro/larastan
+        run: composer remove --dev larastan/larastan
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,13 +30,15 @@ jobs:
             php: 8.1
           - laravel: "^12.0"
             php: 8.1
+          - laravel: "^12.0"
+            php: 8.5
+            stability: prefer-lowest
           - laravel: "^11.0"
             php: 8.5
           - laravel: "^10.0"
             php: 8.5
           - laravel: "^9.38"
             php: 8.5
-
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,8 @@ jobs:
             php: 8.5
           - laravel: "^9.38"
             php: 8.5
+          - laravel: "^10.0"
+            stability: prefer-lowest
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,10 @@
         "composer/semver": "^3.4",
         "guzzlehttp/guzzle": "^7.5",
         "laravel/pint": "^1.0",
-        "nunomaduro/larastan": "^2.0.1|^3.0",
+        "larastan/larastan": "^2.0.1|^3.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.21|^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^1.21|^2.0|^3.0",
-        "phpstan/extension-installer": "^1.1",
-        "spatie/laravel-ray": "^1.26"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "larastan/larastan": "^2.0.1|^3.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.21|^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^1.21|^2.0|^3.0",
+        "pestphp/pest-plugin-laravel": "^1.21|^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,41 +1,97 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method InnoGE\\\\LaravelMsGraphMail\\\\MicrosoftGraphTransport\\:\\:getInternetMessageHeaders\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Cannot access offset ''address'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/LaravelMsGraphMailServiceProvider.php
+
+		-
+			message: '#^Parameter \#1 \$config of method InnoGE\\LaravelMsGraphMail\\LaravelMsGraphMailServiceProvider\:\:requireConfigString\(\) expects array\<string, mixed\>, array given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/LaravelMsGraphMailServiceProvider.php
+
+		-
+			message: '#^Cannot access offset 0 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/MicrosoftGraphTransport.php
 
 		-
-			message: "#^Method InnoGE\\\\LaravelMsGraphMail\\\\MicrosoftGraphTransport\\:\\:transformEmailAddress\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method InnoGE\\LaravelMsGraphMail\\MicrosoftGraphTransport\:\:getInternetMessageHeaders\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/MicrosoftGraphTransport.php
 
 		-
-			message: "#^Method InnoGE\\\\LaravelMsGraphMail\\\\MicrosoftGraphTransport\\:\\:transformEmailAddresses\\(\\) should return array\\<array\\<string, array\\<string, string\\>\\>\\> but returns array\\.$#"
+			message: '#^Method InnoGE\\LaravelMsGraphMail\\MicrosoftGraphTransport\:\:prepareAttachments\(\) should return array\<int, array\<int\<0, max\>, array\<string, bool\|string\|null\>\>\|string\|null\> but returns array\{list\<array\{''@odata\.type''\: ''\#microsoft\.graph…'', name\: mixed, contentType\: non\-falsy\-string, contentBytes\: string, contentId\: mixed, isInline\: bool\}\>, string\|null\}\.$#'
+			identifier: return.type
 			count: 1
 			path: src/MicrosoftGraphTransport.php
 
 		-
-			message: "#^Parameter \\#1 \\$message of static method Symfony\\\\Component\\\\Mime\\\\MessageConverter\\:\\:toEmail\\(\\) expects Symfony\\\\Component\\\\Mime\\\\Message, Symfony\\\\Component\\\\Mime\\\\RawMessage given\\.$#"
+			message: '#^Method InnoGE\\LaravelMsGraphMail\\MicrosoftGraphTransport\:\:transformEmailAddress\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/MicrosoftGraphTransport.php
 
 		-
-			message: "#^Parameter \\#2 \\$html of method InnoGE\\\\LaravelMsGraphMail\\\\MicrosoftGraphTransport\\:\\:prepareAttachments\\(\\) expects string\\|null, resource\\|string\\|null given\\.$#"
+			message: '#^Method InnoGE\\LaravelMsGraphMail\\MicrosoftGraphTransport\:\:transformEmailAddresses\(\) should return array\<array\<string, array\<string, string\>\>\> but returns array\<mixed\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/MicrosoftGraphTransport.php
 
 		-
-			message: "#^Unable to resolve the template type TKey in call to function collect$#"
+			message: '#^Parameter \#1 \$callback of method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:filter\(\) expects \(callable\(mixed, int\|string\)\: bool\)\|null, Closure\(Symfony\\Component\\Mime\\Header\\HeaderInterface\)\: bool given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/MicrosoftGraphTransport.php
 
 		-
-			message: "#^Method InnoGE\\\\LaravelMsGraphMail\\\\Services\\\\MicrosoftGraphApiService\\:\\:getAccessToken\\(\\) should return string but returns mixed\\.$#"
+			message: '#^Parameter \#1 \$callback of method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:map\(\) expects callable\(mixed, int\|string\)\: array\{name\: string, value\: string\}, Closure\(Symfony\\Component\\Mime\\Header\\HeaderInterface\)\: array\{name\: string, value\: string\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/MicrosoftGraphTransport.php
+
+		-
+			message: '#^Parameter \#1 \$message of static method Symfony\\Component\\Mime\\MessageConverter\:\:toEmail\(\) expects Symfony\\Component\\Mime\\Message, Symfony\\Component\\Mime\\RawMessage given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/MicrosoftGraphTransport.php
+
+		-
+			message: '#^Parameter \#1 \$value of function collect expects Illuminate\\Contracts\\Support\\Arrayable\<\(int\|string\), mixed\>\|iterable\<\(int\|string\), mixed\>\|null, iterable given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/MicrosoftGraphTransport.php
+
+		-
+			message: '#^Parameter \#2 \$html of method InnoGE\\LaravelMsGraphMail\\MicrosoftGraphTransport\:\:prepareAttachments\(\) expects string\|null, resource\|string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/MicrosoftGraphTransport.php
+
+		-
+			message: '#^Unable to resolve the template type TKey in call to function collect$#'
+			identifier: argument.templateType
+			count: 1
+			path: src/MicrosoftGraphTransport.php
+
+		-
+			message: '#^Method InnoGE\\LaravelMsGraphMail\\Services\\MicrosoftGraphApiService\:\:getAccessToken\(\) should return string but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Services/MicrosoftGraphApiService.php
 
 		-
-			message: "#^Method InnoGE\\\\LaravelMsGraphMail\\\\Services\\\\MicrosoftGraphApiService\\:\\:sendMail\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
+			message: '#^Method InnoGE\\LaravelMsGraphMail\\Services\\MicrosoftGraphApiService\:\:sendMail\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Services/MicrosoftGraphApiService.php
+
+		-
+			message: '#^Parameter \#2 \$data of method Illuminate\\Http\\Client\\PendingRequest\<false\>\:\:post\(\) expects array\<0\|string, mixed\>\|Illuminate\\Contracts\\Support\\Arrayable\<string, mixed\>\|JsonSerializable, array given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Services/MicrosoftGraphApiService.php

--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -75,13 +75,15 @@ class MicrosoftGraphTransport extends AbstractTransport
         foreach ($email->getAttachments() as $attachment) {
             $headers = $attachment->getPreparedHeaders();
             $fileName = $headers->getHeaderParameter('Content-Disposition', 'filename');
+            // Laravel 12.44.0 bug: Contains a new Content-ID Header with the CID for inline attachments fallback to regular logic using filename for unaffected versions
+            $contentId = $headers->has('Content-ID') ? $headers->get('Content-ID')?->getBody()[0] ?? null : null;
 
             $attachments[] = [
                 '@odata.type' => '#microsoft.graph.fileAttachment',
                 'name' => $fileName,
                 'contentType' => implode('/', [$attachment->getMediaType(), $attachment->getMediaSubtype()]),
                 'contentBytes' => base64_encode($attachment->getBody()),
-                'contentId' => $fileName,
+                'contentId' => filled($contentId) ? $contentId : $fileName,
                 'isInline' => $headers->getHeaderBody('Content-Disposition') === 'inline',
             ];
         }

--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -77,13 +77,14 @@ class MicrosoftGraphTransport extends AbstractTransport
             $fileName = $headers->getHeaderParameter('Content-Disposition', 'filename');
             // Laravel 12.44.0 bug: Contains a new Content-ID Header with the CID for inline attachments fallback to regular logic using filename for unaffected versions
             $contentId = $headers->has('Content-ID') ? $headers->get('Content-ID')?->getBody()[0] ?? null : null;
+            $contentId = filled($contentId) ? $contentId : $fileName;
 
             $attachments[] = [
                 '@odata.type' => '#microsoft.graph.fileAttachment',
-                'name' => $fileName,
+                'name' => $contentId,
                 'contentType' => implode('/', [$attachment->getMediaType(), $attachment->getMediaSubtype()]),
                 'contentBytes' => base64_encode($attachment->getBody()),
-                'contentId' => filled($contentId) ? $contentId : $fileName,
+                'contentId' => $contentId,
                 'isInline' => $headers->getHeaderBody('Content-Disposition') === 'inline',
             ];
         }

--- a/tests/Resources/views/html-mail-with-mixed-attachments.blade.php
+++ b/tests/Resources/views/html-mail-with-mixed-attachments.blade.php
@@ -1,0 +1,2 @@
+<b>Test with mixed attachments</b>
+<img src="{{ $message->embed(\Illuminate\Support\Facades\Storage::path('blue.jpg')) }}">

--- a/tests/Resources/views/html-mail-with-multiple-inline-images.blade.php
+++ b/tests/Resources/views/html-mail-with-multiple-inline-images.blade.php
@@ -1,0 +1,3 @@
+<b>Test with multiple images</b>
+<img src="{{ $message->embed(\Illuminate\Support\Facades\Storage::path('blue.jpg')) }}">
+<img src="{{ $message->embed(\Illuminate\Support\Facades\Storage::path('blue.jpg')) }}">

--- a/tests/Stubs/TestMailWithMixedAttachments.php
+++ b/tests/Stubs/TestMailWithMixedAttachments.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace InnoGE\LaravelMsGraphMail\Tests\Stubs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Attachment;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class TestMailWithMixedAttachments extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Dev Test',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(html: 'html-mail-with-mixed-attachments');
+    }
+
+    /**
+     * Get the attachments for the message.
+     */
+    public function attachments(): array
+    {
+        return [
+            Attachment::fromPath('tests/Resources/files/test-file-1.txt'),
+        ];
+    }
+}

--- a/tests/Stubs/TestMailWithMultipleInlineImages.php
+++ b/tests/Stubs/TestMailWithMultipleInlineImages.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace InnoGE\LaravelMsGraphMail\Tests\Stubs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class TestMailWithMultipleInlineImages extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Dev Test',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(html: 'html-mail-with-multiple-inline-images');
+    }
+}


### PR DESCRIPTION
This PR implements a workaround for a breaking change introduced in Laravel 12.44.0 (via https://github.com/laravel/framework/pull/57726) that broke inline image attachments in emails.

  ## The Problem

  Laravel 12.44.0 changed how DataPart handles Content-IDs for inline attachments. Previously, the filename was used as the Content-ID. After the change, DataPart generates its own unique Content-ID, which is now exposed via a new Content-ID header. This broke inline image embedding because:

  1. The HTML content references images via cid:<content-id>
  2. The Microsoft Graph API needs the contentId field to match what's in the HTML
  3. Without this fix, the contentId was set to the filename, not the actual Content-ID from the header

  ## The Fix

  - Extract the Content-ID from the Content-ID header when available (Laravel 12.44.0+)
  - Fall back to using the filename for older Laravel versions that don't have this header
  - Use the resolved Content-ID for both the name and contentId fields in the Graph API payload

closes #58 

Thanks to @Fradd747 for reporting and an initial fix