### PR TITLE
use filename for attachment name, if available

### DIFF
--- a/src/MicrosoftGraphTransport.php
+++ b/src/MicrosoftGraphTransport.php
@@ -81,7 +81,7 @@ class MicrosoftGraphTransport extends AbstractTransport
 
             $attachments[] = [
                 '@odata.type' => '#microsoft.graph.fileAttachment',
-                'name' => $contentId,
+                'name' => $attachment->getFilename() ?? $contentId,
                 'contentType' => implode('/', [$attachment->getMediaType(), $attachment->getMediaSubtype()]),
                 'contentBytes' => base64_encode($attachment->getBody()),
                 'contentId' => $contentId,


### PR DESCRIPTION
When attaching images, some mail clients (Thunderbird) require the name to end with a proper suffix (e.g. .jpg) in order to render inline images.